### PR TITLE
Add IAM role to upload 'ad-network-receiver' artifacts on GitHub Actions

### DIFF
--- a/stacks/terraform/stacks/ad-network/receiver/iam.tf
+++ b/stacks/terraform/stacks/ad-network/receiver/iam.tf
@@ -1,0 +1,48 @@
+data "aws_iam_policy_document" "github_actions_assume_role" {
+  statement {
+    principals {
+      type        = "Federated"
+      identifiers = [local.github_actions_oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:scizorman/aws-playground:*"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+  }
+}
+
+resource "aws_iam_role" "github_actions_artifact_uploader" {
+  name               = local.github_actions_artifact_uploader_role_name
+  description        = "IAM role for uploading ${local.name} artifacts built on GitHub Actions to S3 bucket"
+  assume_role_policy = data.aws_iam_policy_document.github_actions_assume_role.json
+
+  tags = { Name = local.github_actions_artifact_uploader_role_name }
+}
+
+resource "aws_iam_role_policy" "github_actions_artifact_uploader" {
+  name   = local.github_actions_artifact_uploader_role_name
+  role   = aws_iam_role.github_actions_artifact_uploader.name
+  policy = data.aws_iam_policy_document.githubactions_artifact_uploader.json
+}
+
+data "aws_iam_policy_document" "githubactions_artifact_uploader" {
+  statement {
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.artifact.arn]
+  }
+
+  statement {
+    actions   = ["s3:*Object"]
+    resources = ["${aws_s3_bucket.artifact.arn}/*"]
+  }
+}

--- a/stacks/terraform/stacks/ad-network/receiver/locals.tf
+++ b/stacks/terraform/stacks/ad-network/receiver/locals.tf
@@ -16,4 +16,7 @@ locals {
   alb_log_bucket_name        = "${local.name}-alb-log"
   alb_access_logs_prefix     = "${local.name}-alb-access-log"
   alb_connection_logs_prefix = "${local.name}-alb-connection-log"
+
+  github_actions_oidc_provider_arn           = "arn:aws:iam::217082601537:oidc-provider/token.actions.githubusercontent.com"
+  github_actions_artifact_uploader_role_name = "${local.name}-github-actions-artifact-uploader"
 }


### PR DESCRIPTION
As the title says.